### PR TITLE
Forcing tab to use spaces, since drafter doesn't currently support tabs

### DIFF
--- a/apib-mode.el
+++ b/apib-mode.el
@@ -112,7 +112,7 @@ with parsing output."
                    "drafter binary not found, please install it in your exec-path")
                   (nil))
          (concat apib-drafter-executable " -f json -u " buffer-file-name)))
-
+  (setq indent-tabs-mode nil)
   (eval-after-load "compilation"
     (progn
       (add-to-list 'compilation-error-regexp-alist-alist


### PR DESCRIPTION
When I first set up apib-mode, I ended up with apib-validate failing because drafter didn't support tab characters for indenting code blocks. This forces apib-mode to use spaces instead, and now drafter and apib-validate work great!
