### PR TITLE
Load parent-mode

### DIFF
--- a/apib-mode.el
+++ b/apib-mode.el
@@ -59,6 +59,7 @@
 (require 'font-lock)
 (require 'compile)
 (require 'json)
+(require 'markdown-mode)
 
 (defcustom apib-drafter-executable
   "drafter"


### PR DESCRIPTION
`parent-mode` should be loaded. If it is not loaded, then following error occurs.

```
let: Symbol’s function definition is void: markdown-mode
```